### PR TITLE
RFC: Eval scope 

### DIFF
--- a/src/zmq_server_julia.jl
+++ b/src/zmq_server_julia.jl
@@ -25,7 +25,7 @@ function zmqquit()
     exit()
 end
 
-function run_server(endpoint::ASCIIString)
+function run_server(scope, endpoint::ASCIIString)
     global _responder
     zctx = ZMQContext()
     _responder = ZMQSocket(zctx, ZMQ_REP)
@@ -44,7 +44,7 @@ function run_server(endpoint::ASCIIString)
         # Execute the command
         local ret
         try
-            ret = eval(ex)
+            ret = eval(scope,ex)
         catch thiserr
             respond_error(_responder, thiserr)
             continue
@@ -58,3 +58,6 @@ function run_server(endpoint::ASCIIString)
     end
 end
 run_server() = run_server("tcp://*:5555")
+run_server(endpoint::ASCIIString) = run_server(current_module(), endpoint)
+
+current_module() = ccall(:jl_get_current_module, Any, ())::Module


### PR DESCRIPTION
As a replacement for #7 . I think this is a slightly cleaner/simpler solution. 

@timholy @rened : Thoughts? We can merge #7 if you don't like this. 

Thanks to @timholy for discovering the trick to get current module. 

``` jlcon
julia> function tst(a); return a*2; end
# method added to generic function tst

julia> require("ZMQ/src/RPCJuliaSer"); using RPCJuliaSer; run_server()
```

``` jlcon
julia> require("ZMQ/src/RPCJuliaSer"); using RPCJuliaSer; c,r = launch_client()
(ZMQContext(Ptr{Void} @0x00000001038a03f0),ZMQSocket(Ptr{Void} @0x000000010389c0e0))

julia> zmqcall(r, :tst, 2)
4
```
