### PR TITLE
fix send() and recv() when version == 3

### DIFF
--- a/src/ZMQ.jl
+++ b/src/ZMQ.jl
@@ -424,7 +424,7 @@ elseif _zmq_major == 3
     function send(socket::ZMQSocket, zmsg::ZMQMessage, flag::Integer)
         rc = ccall((:zmq_msg_send, :libzmq), Int32, (Ptr{Void}, Ptr{Uint8}, Int32),
                     zmsg.obj, socket.data, flag)
-        if rc != 0
+        if rc == -1
             throw(ZMQStateError(jl_zmq_error_str()))
         end
     end
@@ -453,7 +453,7 @@ elseif _zmq_major == 3
         zmsg = ZMQMessage()
         rc = ccall((:zmq_msg_recv, :libzmq), Int32, (Ptr{Void}, Ptr{Void}, Int32),
                     zmsg.obj, socket.data, flag)
-        if rc != 0
+        if rc == -1
             throw(ZMQStateError(jl_zmq_error_str()))
         end
         return zmsg


### PR DESCRIPTION
In zeromq version 3, function `zmq_msg_recv()` and `zmq_msg_send()` shall return number of bytes in the message if successful, otherwise it shall return -1. 

Possibly fix issue #3
