### PR TITLE
Switch to a WinRPM binary, fixes #65

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
 BinDeps 0.2.1-
 @osx Homebrew
 Compat 0.2
+@windows WinRPM

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -8,7 +8,8 @@ provides(Sources,URI("http://download.zeromq.org/zeromq-3.2.4.tar.gz"),zmq)
 provides(BuildProcess,Autotools(libtarget = "src/.libs/libzmq."*BinDeps.shlib_ext),zmq)
 
 @windows_only begin
-    provides(Binaries, {URI("http://s3.amazonaws.com/julialang/bin/winnt/extras/libzmq-3.3-x$WORD_SIZE.zip") => zmq}, os = :Windows )
+    using WinRPM
+    provides(WinRPM.RPM, "zeromq", [zmq], os = :Windows)
 end
 
 @osx_only begin


### PR DESCRIPTION
This download works behind proxies which BinDeps' binary provider currently doesn't on Windows. This also properly handles simultaneously installing 32 and 64 bit versions of the package on the same computer, which is something Julia developers on Windows often need to do, and some users as well.

This can also be kept up-to-date very easily by anyone at https://build.opensuse.org/package/show/windows:mingw:win64/mingw64-zeromq (or https://build.opensuse.org/package/show/windows:mingw:win32/mingw32-zeromq for 32 bit), you just need to sign up for an account on the openSUSE build service to branch the package and make change requests. Works a lot like github. This particular package has just about the simplest possible spec file, so would be a good example for anyone who wants to get more familiar with distributing packages through WinRPM.

cc @stevengj @ihnorton @Keno @djpeaco
fixes #65