### PR TITLE
remove - on julia version in REQUIRE

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.3-
+julia 0.3
 BinDeps 0.2.1-
 @osx Homebrew
 Compat 0.4


### PR DESCRIPTION
speak now or forever hold your peace if you really need latest zmq.jl to run on prereleases of 0.3