### PR TITLE
drop support for ZMQ v2 and add support for precompiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@
 
 **ZMQ.jl** is a [Julia] (http://julialang.org) interface to [ZeroMQ, The Intelligent Transport Layer] (http://zeromq.org). 
 
-This codebase has been tested to work with ZeroMQ version 2.2.0 and 3.2.2. The unit tests within this package run successfully on both versions of the library. 
-
+ZMQ version 3 or later is required; ZMQ version 2 is not supported.
 
 ## Installation
 ```julia

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,21 +31,13 @@ end
 
 
 s1=Socket(ctx2, REP)
-if ZMQ.version.major == 2 
-	ZMQ.set_hwm(s1, 1000)
-else 
-	ZMQ.set_sndhwm(s1, 1000)
-end
+ZMQ.set_sndhwm(s1, 1000)
 ZMQ.set_linger(s1, 1)
 ZMQ.set_identity(s1, "abcd")
 
 
 @assert ZMQ.get_identity(s1)::AbstractString == "abcd"
-if ZMQ.version.major == 2
-	@assert ZMQ.get_hwm(s1)::Integer == 1000
-else
-	@assert ZMQ.get_sndhwm(s1)::Integer == 1000
-end
+@assert ZMQ.get_sndhwm(s1)::Integer == 1000
 @assert ZMQ.get_linger(s1)::Integer == 1
 @assert ZMQ.ismore(s1) == false 
 


### PR DESCRIPTION
As discussed in #85, ZMQ version 2 dates to 2011, and it is much simpler to drop support for that version at this point.   This allows us to easily support precompiling in Julia 0.4.

I don't think this should affect any downstream packages.   Anything relying on ZMQ v2 APIs should be checking `ZMQ.version` anyway, and that will always be `> v"2"` now.