### PR TITLE
Update README example to not throw

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ msg = ZMQ.recv(s1)
 out=convert(IOStream, msg)
 seek(out,0)
 #read out::MemIO as usual, eg. read(out,...) or takebuf_string(out)
-#or, conveniently, use ASCIIString[msg] to retrieve a string
+#or, conveniently, use bytestring(msg) to retrieve a string
 
 ZMQ.send(s1, Message("test response"))
 ZMQ.close(s1)


### PR DESCRIPTION
Cool library, thanks for writing this.

The readme seems to have an older way to convert messages to strings.

The error I get when I run `ASCIIString[msg]` is:

```julia
ERROR: LoadError: MethodError: `convert` has no method matching convert(::Type{ASCIIString}, ::ZMQ.Message)
This may have arisen from a call to the constructor ASCIIString(...),
since type constructors fall back to convert methods.
Closest candidates are:
  call{T}(::Type{T}, ::Any)
  convert(::Type{ASCIIString}, !Matched::ASCIIString)
```

This patch updates the readme to use the method you use in your test cases: `bytestring(msg)`