### PR TITLE
Update the version of BinDeps in REQUIRE

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.3
-BinDeps 0.2.1-
+BinDeps 0.3.21
 @osx Homebrew
 Compat 0.8.0
 @windows WinRPM


### PR DESCRIPTION
To tag the ZMQ.jl v0.3.4, updated the version of the BinDeps.
details at https://github.com/JuliaLang/ZMQ.jl/issues/110 