### PR TITLE
Qualify which brew formula to use

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -17,7 +17,7 @@ if is_apple()
     if Pkg.installed("Homebrew") === nothing
         error("Homebrew package not installed, please run Pkg.add(\"Homebrew\")")  end
     using Homebrew
-    provides( Homebrew.HB, "zeromq32", zmq, os = :Darwin )
+    provides( Homebrew.HB, "staticfloat/juliadeps/zeromq32", zmq, os = :Darwin )
 end
 
 @BinDeps.install @compat Dict(:zmq => :zmq)


### PR DESCRIPTION
This fix avoids a potential conflict when updating an existing ZMQ
instance which has tapped the default homebrew formula previously, e.g.:

```jl
julia> Pkg.build("IJulia")
INFO: Building Homebrew
Already up-to-date.
INFO: Building Nettle
INFO: Building ZMQ
Error: Formulae found in multiple taps:
 * homebrew/versions/zeromq32
 * staticfloat/juliadeps/zeromq32

Please use the fully-qualified name e.g. homebrew/versions/zeromq32 to
refer the formula.
```