### PR TITLE
Implement `Base.show()` methods for Socket and Context

### DIFF
--- a/docs/src/_changelog.md
+++ b/docs/src/_changelog.md
@@ -7,6 +7,12 @@ CurrentModule = ZMQ
 This documents notable changes in ZMQ.jl. The format is based on [Keep a
 Changelog](https://keepachangelog.com).
 
+## Unreleased
+
+### Changed
+- Implemented `Base.show()` methods for [`Socket`](@ref) and [`Context`](@ref)
+  for pretty-printing ([#255]).
+
 ## [v1.4.0] - 2024-11-30
 
 ### Added

--- a/src/context.jl
+++ b/src/context.jl
@@ -38,6 +38,14 @@ function Context(f::Function, args...)
     end
 end
 
+function Base.show(io::IO, ctx::Context)
+    if isopen(ctx)
+        print(io, Context, "($(getfield(ctx, :sockets)))")
+    else
+        print(io, Context, "([closed])")
+    end
+end
+
 Base.unsafe_convert(::Type{Ptr{Cvoid}}, c::Context) = getfield(c, :data)
 
 # define a global context that is initialized lazily

--- a/src/context.jl
+++ b/src/context.jl
@@ -42,7 +42,7 @@ function Base.show(io::IO, ctx::Context)
     if isopen(ctx)
         print(io, Context, "($(getfield(ctx, :sockets)))")
     else
-        print(io, Context, "([closed])")
+        print(io, Context, "() (closed)")
     end
 end
 

--- a/src/socket.jl
+++ b/src/socket.jl
@@ -45,6 +45,30 @@ function Socket(f::Function, args...)
     end
 end
 
+const _socket_type_names = Dict(
+    lib.ZMQ_PAIR => "PAIR",
+    lib.ZMQ_PUB => "PUB",
+    lib.ZMQ_SUB => "SUB",
+    lib.ZMQ_REQ => "REQ",
+    lib.ZMQ_REP => "REP",
+    lib.ZMQ_DEALER => "DEALER",
+    lib.ZMQ_ROUTER => "ROUTER",
+    lib.ZMQ_PULL => "PULL",
+    lib.ZMQ_PUSH => "PUSH",
+    lib.ZMQ_XPUB => "XPUB",
+    lib.ZMQ_XSUB => "XSUB"
+)
+
+function Base.show(io::IO, socket::Socket)
+    if isopen(socket)
+        type_name = _socket_type_names[socket.type]
+        last_endpoint = socket.last_endpoint == "\0" ? "" : ", $(socket.last_endpoint)"
+        print(io, Socket, "($(type_name)$(last_endpoint))")
+    else
+        print(io, Socket, "([closed])")
+    end
+end
+
 Base.unsafe_convert(::Type{Ptr{Cvoid}}, s::Socket) = getfield(s, :data)
 
 """

--- a/src/socket.jl
+++ b/src/socket.jl
@@ -62,10 +62,10 @@ const _socket_type_names = Dict(
 function Base.show(io::IO, socket::Socket)
     if isopen(socket)
         type_name = _socket_type_names[socket.type]
-        last_endpoint = socket.last_endpoint == "\0" ? "" : ", $(socket.last_endpoint)"
+        last_endpoint = socket.last_endpoint == "\0" ? "" : ", $(socket.last_endpoint[1:end-1])"
         print(io, Socket, "($(type_name)$(last_endpoint))")
     else
-        print(io, Socket, "([closed])")
+        print(io, Socket, "() (closed)")
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,9 +23,9 @@ using ZMQ, Test
 
     # Smoke tests for Base.show()
     ctx = Context()
-    show(IOBuffer(), ctx)
+    @test repr(ctx) == "Context(WeakRef[])"
     close(ctx)
-    show(IOBuffer(), ctx)
+    @test repr(ctx) == "Context() (closed)"
 end
 
 # This test is in its own function to keep it simple and try to trick Julia into
@@ -166,11 +166,11 @@ end
 
     # Smoke tests for Base.show() in different Socket situations
     s1 = Socket(REP)
-    show(IOBuffer(), s1)
-    ZMQ.bind(s1, "tcp://127.0.0.1:*")
-    show(IOBuffer(), s1)
+    @test repr(s1) == "Socket(REP)"
+    ZMQ.bind(s1, "tcp://127.0.0.1:5555")
+    @test repr(s1) == "Socket(REP, tcp://127.0.0.1:5555)"
     close(s1)
-    show(IOBuffer(), s1)
+    @test repr(s1) == "Socket() (closed)"
 end
 
 @testset "Message" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,6 +20,12 @@ using ZMQ, Test
 
     #try to create socket with expired context
     @test_throws StateError Socket(ctx, PUB)
+
+    # Smoke tests for Base.show()
+    ctx = Context()
+    show(IOBuffer(), ctx)
+    close(ctx)
+    show(IOBuffer(), ctx)
 end
 
 # This test is in its own function to keep it simple and try to trick Julia into
@@ -157,6 +163,14 @@ end
     ZMQ.close(ZMQ._context) # immediately close global context rather than waiting for exit
     @test !isopen(s1)
     @test !isopen(s2)
+
+    # Smoke tests for Base.show() in different Socket situations
+    s1 = Socket(REP)
+    show(IOBuffer(), s1)
+    ZMQ.bind(s1, "tcp://127.0.0.1:*")
+    show(IOBuffer(), s1)
+    close(s1)
+    show(IOBuffer(), s1)
 end
 
 @testset "Message" begin


### PR DESCRIPTION
Socket example:
```julia-repl
julia> x = ZMQ.Socket(ZMQ.REP)
ZMQ.Socket(REP)

julia> x
ZMQ.Socket(REP)

julia> ZMQ.bind(x, "tcp://localhost:*")

julia> x
ZMQ.Socket(REP, tcp://127.0.0.1:42099)

julia> close(x)

julia> x
ZMQ.Socket([closed])
```

Context example:
```julia-repl
julia> x = ZMQ.Context()
ZMQ.Context(WeakRef[])

julia> close(x)

julia> x
ZMQ.Context([closed])
```