### PR TITLE
Hardcode precompilation IP address to 127.0.0.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ZMQ"
 uuid = "c2297ded-f4af-51ae-bb23-16f91089e4e1"
-version = "1.4.0"
+version = "1.4.1"
 
 [deps]
 FileWatching = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"

--- a/docs/src/_changelog.md
+++ b/docs/src/_changelog.md
@@ -7,11 +7,16 @@ CurrentModule = ZMQ
 This documents notable changes in ZMQ.jl. The format is based on [Keep a
 Changelog](https://keepachangelog.com).
 
-## Unreleased
+## [v1.4.1] - 2025-06-13
 
 ### Changed
 - Implemented `Base.show()` methods for [`Socket`](@ref) and [`Context`](@ref)
   for pretty-printing ([#255]).
+
+### Fixed
+- The precompilation workload now hardcodes the use of IP address `127.0.0.1`
+  instead of resolving `localhost`, which fixes precompilation on machines that
+  may have `localhost` resolve to a different node ([#257]).
 
 ## [v1.4.0] - 2024-11-30
 

--- a/src/ZMQ.jl
+++ b/src/ZMQ.jl
@@ -68,14 +68,13 @@ import PrecompileTools: @compile_workload
 
     s2=Socket(REQ)
 
-    # zmq < 4.3.5 can only bind to ip address or network interface, not hostname
-    localhost_ip = Sockets.getaddrinfo("localhost", Sockets.IPv4)
-    ZMQ.bind(s1, "tcp://$(localhost_ip):*")
+    # Note that ZMQ < 4.3.5 can only bind to IP address or network interface, not hostname
+    ZMQ.bind(s1, "tcp://127.0.0.1:*")
     # Strip the trailing null-terminator
     last_endpoint = s1.last_endpoint[1:end - 1]
     # Parse the port from the endpoint
     port = parse(Int, split(last_endpoint, ":")[end])
-    ZMQ.connect(s2, "tcp://$(localhost_ip):$(port)")
+    ZMQ.connect(s2, "tcp://127.0.0.1:$(port)")
 
     msg = Message("test request")
 


### PR DESCRIPTION
`localhost` may resolve to a different machine in some cases, so now we just hardcode the IP address instead.

Fixes https://github.com/JuliaLang/IJulia.jl/issues/1121.