### PR TITLE
Alternative approach to fixing Poller races/hangs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,6 +12,7 @@ ZeroMQ_jll = "8f1865be-045e-5c20-9c9f-bfbfb0764568"
 [compat]
 Aqua = "0.8.7"
 FileWatching = "<0.0.1, 1"
+Logging = "<0.0.1, 1"
 PrecompileTools = "1"
 Printf = "<0.0.1, 1"
 Sockets = "<0.0.1, 1"
@@ -21,7 +22,8 @@ julia = "1.10"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "Test"]
+test = ["Aqua", "Logging", "Test"]

--- a/src/error.jl
+++ b/src/error.jl
@@ -16,8 +16,8 @@ struct TimeoutError <: Exception
     timeout_secs::Float64
 end
 
-Base.show(io::IO, thiserr::StateError) = print(io, "ZMQ: ", thiserr.msg)
-Base.show(io::IO, thiserr::TimeoutError) = print(io, TimeoutError, ": $(thiserr.msg)")
+Base.showerror(io::IO, thiserr::StateError) = print(io, "ZMQ: ", thiserr.msg)
+Base.showerror(io::IO, thiserr::TimeoutError) = print(io, TimeoutError, ": $(thiserr.msg)")
 
 # Basic functions
 

--- a/src/poller.jl
+++ b/src/poller.jl
@@ -177,10 +177,10 @@ function handle_pollitem(item::PollItem, poller::Poller)
     barrier = poller.barrier
 
     try
-        while isopen(poller.channel)
+        while isopen(poller)
             # resting/disarmed block until barrier is notified (begins `wait(::Poller)`
             waiter_wait(barrier)
-            if !isopen(poller.channel)
+            if !isopen(poller)
                 cancel_socket_wait(item)
                 return
             end

--- a/src/poller.jl
+++ b/src/poller.jl
@@ -80,7 +80,11 @@ This object can be passed to a [`Poller`](@ref) to indicate whether the poller
 should wait for `socket` to become readable (`ZMQ_POLLIN`) or writable
 (`ZMQ_POLLOUT`).
 """
-PollItem(socket::Socket; readable=true, writable=false) = PollItem(socket, readable, writable)
+function PollItem(socket::Socket; readable=true, writable=false)
+    readable || writable || throw(ArgumentError("at least one poll state (readable or writable) must be set true"))
+    PollItem(socket, readable, writable)
+end
+
 """
 This object represents an event on a socket. It's returned by
 [`wait(::Poller)`](@ref).

--- a/src/poller.jl
+++ b/src/poller.jl
@@ -234,7 +234,8 @@ function handle_pollitem(item::PollItem, poller::Poller)
         # reachable by:
         #   - `put!` on already closed channel
         #   - `fetch`ing a failed socket waiter
-        cancel_socket_wait(item)
+        #   - respawning failed
+        # in all cases, the socket_waiter will already be canceled or done (failed)
         close(poller.channel, err)
     finally
         handle_waiter_exit(barrier)

--- a/src/poller.jl
+++ b/src/poller.jl
@@ -345,7 +345,11 @@ function clear_wakeup_events(poller::Poller)
     for item in poller.items
         if isopen(item.socket)
             pollfd = getfield(item.socket, :pollfd)
-            pollfd.watcher.events &= ~WAKEUP
+            events = pollfd.watcher.events
+            # if (events & WAKEUP) == WAKEUP
+            #     @error "" item.socket, events exception=(ErrorException(""), backtrace())
+            # end
+            @lock pollfd.watcher.notify pollfd.watcher.events &= ~WAKEUP
         end
     end
 end

--- a/src/socket.jl
+++ b/src/socket.jl
@@ -66,8 +66,18 @@ const _socket_type_names = Dict(
 
 function Base.show(io::IO, socket::Socket)
     if isopen(socket)
-        type_name = _socket_type_names[socket.type]
-        last_endpoint = socket.last_endpoint == "\0" ? "" : ", $(socket.last_endpoint[1:end-1])"
+        type_name, last_endpoint = try
+            _socket_type_names[socket.type], socket.last_endpoint
+        catch ex
+            if !(ex isa StateError)
+                rethrow()
+            end
+
+            print(io, Socket, "() (unknown state)")
+            return
+        end
+
+        last_endpoint = last_endpoint == "\0" ? "" : ", $(last_endpoint[1:end-1])"
         print(io, Socket, "($(type_name)$(last_endpoint))")
     else
         print(io, Socket, "() (closed)")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -408,8 +408,8 @@ end
 
 @testset "Utilities" begin
     @test ZMQ.lib_version() isa VersionNumber
-    @test repr(ZMQ.StateError("foo")) == "ZMQ: foo"
-    @test repr(ZMQ.TimeoutError("Foo", 1.2)) == "ZMQ.TimeoutError: Foo"
+    @test sprint(showerror, ZMQ.StateError("foo")) == "ZMQ: foo"
+    @test sprint(showerror, ZMQ.TimeoutError("Foo", 1.2)) == "ZMQ.TimeoutError: Foo"
 end
 
 @testset "Aqua.jl" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -352,7 +352,7 @@ end
     # Test behaviour when a waiter task dies, e.g. because the socket is closed
     ZMQ.Poller([sub1, sub2]) do poller
         close(sub1)
-        @test_warn r"Socket error when polling" @test_throws ErrorException wait(poller)
+        @test_throws StateError wait(poller)
     end
 
     # It shouldn't be possible to create a poller with closed sockets


### PR DESCRIPTION
In case it might be helpful, here is my current best functioning (read: least hang-y
:zany_face:) attempt at a fix for `Poller`.

The tl;dr is that with these changes, the IJulia PR gets through all tests (with only a
couple failures, including a couple timeout's aka kernel/poller hangs), but only with
verbose/debug logging. I believe that confirms that the issue isn't with the IJulia
eventloop flow, and suggests that there is still a race(?) somewhere in the `Poller`
implementation.

(Replaces #266 )
